### PR TITLE
Fix compilation failure for versions of Ubuntu later than 16.04

### DIFF
--- a/include/viface/viface.hpp
+++ b/include/viface/viface.hpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <functional>
 
 #include "viface/config.hpp"
 


### PR DESCRIPTION
Add missing include (functional) causing compilation failure in versions of Ubuntu > 16.04.