### PR TITLE
Add missing viface/utils.hpp header to install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ endif(VIFACE_EXAMPLES)
 install(
     FILES
     "${libviface_SOURCE_DIR}/include/viface/viface.hpp"
+    "${libviface_SOURCE_DIR}/include/viface/utils.hpp"
     "${CMAKE_BINARY_DIR}/include/viface/config.hpp"
     DESTINATION
     "${CMAKE_INSTALL_INCLUDEDIR}/viface"


### PR DESCRIPTION
This fixes the `libviface/examples/dispatch/dispatch.cpp` example.